### PR TITLE
Acceptance filter update for new transport layer

### DIFF
--- a/libuavcan/include/uavcan/transport/can_acceptance_filter_configurator.hpp
+++ b/libuavcan/include/uavcan/transport/can_acceptance_filter_configurator.hpp
@@ -16,10 +16,8 @@
 
 namespace uavcan
 {
-/**
- * These arguments defines whether acceptance filter configuration has anonymous massages or not
- */
-enum AnonMassagePresence {WithAnonMsg,NoAnonMsg};
+
+
 
 /**
  * This class configures hardware acceptance filters (if this feature is present on the particular CAN driver) to
@@ -38,6 +36,13 @@ enum AnonMassagePresence {WithAnonMsg,NoAnonMsg};
  */
 class CanAcceptanceFilterConfigurator
 {
+public:
+	/**
+	 * These arguments defines whether acceptance filter configuration has anonymous messages or not
+	 */
+	enum AnonMessagePresence {WithAnonMsg,NoAnonMsg};
+
+private:
     /**
      * Below constants based on UAVCAN transport layer specification. Masks and ID's depends on message
      * TypeID, TransferID (RequestNotResponse - for service types, ServiceNotMessage - for all types of messages).
@@ -51,7 +56,7 @@ class CanAcceptanceFilterConfigurator
      * HW filters.
      * DefaultAnonMsgMask = 00000 00000000 00000000 11111111
      * DefaultAnonMsgID   = 00000 00000000 00000000 00000000, by default the config is added to accept all anonymous
-     * frames. In case there are no anonymous massages, invoke configureFilters(NoAnonMsg).
+     * frames. In case there are no anonymous messages, invoke configureFilters(NoAnonMsg).
      */
     static const unsigned DefaultFilterMsgMask = 0xFFFF80;
     static const unsigned DefaultFilterServiceMask = 0x7F80;
@@ -68,7 +73,7 @@ class CanAcceptanceFilterConfigurator
     /**
      * Fills the multiset_configs_ to proceed it with computeConfiguration()
      */
-    int16_t loadInputConfiguration(AnonMassagePresence load_mode);
+    int16_t loadInputConfiguration(AnonMessagePresence load_mode);
 
     /**
      * This method merges several listeners's filter configurations by predetermined algorithm
@@ -93,10 +98,10 @@ public:
     /**
      * This method invokes loadInputConfiguration(), computeConfiguration() and applyConfiguration() consequently, so
      * that optimal acceptance filter configuration will be computed and loaded through CanDriver::configureFilters()
-     * @return 0 = success, negative for error. Input argument defines the presence of anonymous massages
+     * @return 0 = success, negative for error. Input argument defines the presence of anonymous messages
      * WithAnonMsg(default)/NoAnonMsg.
      */
-    int configureFilters(AnonMassagePresence mode = WithAnonMsg);
+    int configureFilters(AnonMessagePresence mode = WithAnonMsg);
 
     /**
      * Returns the configuration computed with computeConfiguration().

--- a/libuavcan/include/uavcan/transport/can_acceptance_filter_configurator.hpp
+++ b/libuavcan/include/uavcan/transport/can_acceptance_filter_configurator.hpp
@@ -16,9 +16,6 @@
 
 namespace uavcan
 {
-
-
-
 /**
  * This class configures hardware acceptance filters (if this feature is present on the particular CAN driver) to
  * preclude reception of irrelevant CAN frames on the hardware level.
@@ -40,7 +37,7 @@ public:
 	/**
 	 * These arguments defines whether acceptance filter configuration has anonymous messages or not
 	 */
-	enum AnonMessagePresence {WithAnonMsg,NoAnonMsg};
+	enum AnonymousMessages {AcceptAnonymousMessages,IgnoreAnonymousMessages};
 
 private:
     /**
@@ -61,7 +58,7 @@ private:
     static const unsigned DefaultFilterMsgMask = 0xFFFF80;
     static const unsigned DefaultFilterServiceMask = 0x7F80;
     static const unsigned DefaultFilterServiceID = 0x80;
-    static const unsigned DefaultAnonMsgMask = 0xF;
+    static const unsigned DefaultAnonMsgMask = 0xFF;
     static const unsigned DefaultAnonMsgID = 0x0;
 
     typedef uavcan::Multiset<CanFilterConfig, 1> MultisetConfigContainer;
@@ -73,7 +70,7 @@ private:
     /**
      * Fills the multiset_configs_ to proceed it with computeConfiguration()
      */
-    int16_t loadInputConfiguration(AnonMessagePresence load_mode);
+    int16_t loadInputConfiguration(AnonymousMessages load_mode);
 
     /**
      * This method merges several listeners's filter configurations by predetermined algorithm
@@ -101,7 +98,7 @@ public:
      * @return 0 = success, negative for error. Input argument defines the presence of anonymous messages
      * WithAnonMsg(default)/NoAnonMsg.
      */
-    int configureFilters(AnonMessagePresence mode = WithAnonMsg);
+    int configureFilters(AnonymousMessages mode = AcceptAnonymousMessages);
 
     /**
      * Returns the configuration computed with computeConfiguration().

--- a/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
+++ b/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
@@ -9,18 +9,30 @@
 namespace uavcan
 {
 const unsigned CanAcceptanceFilterConfigurator::DefaultFilterMsgMask;
-const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceRequestID;
-const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceRequestMask;
-const unsigned CanAcceptanceFilterConfigurator::ServiceRespFrameID;
-const unsigned CanAcceptanceFilterConfigurator::ServiceRespFrameMask;
+const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceID;
+const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceMask;
+const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgMask;
+const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgID;
 
-int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration()
+int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration(AnonMassagePresence load_mode)
 {
     multiset_configs_.clear();
 
+    if (load_mode == WithAnonMsg)
+    {
+        CanFilterConfig anon_frame_cfg;
+        anon_frame_cfg.id = DefaultAnonMsgID;
+        anon_frame_cfg.mask = DefaultAnonMsgMask;
+        if (multiset_configs_.emplace(anon_frame_cfg) == NULL)
+        {
+            return -ErrMemory;
+        }
+    }
+
     CanFilterConfig service_resp_cfg;
-    service_resp_cfg.id = ServiceRespFrameID;
-    service_resp_cfg.mask = ServiceRespFrameMask;
+    service_resp_cfg.id = DefaultFilterServiceID;
+    service_resp_cfg.id |= static_cast<uint32_t>(node_.getNodeID().get()) << 8;
+    service_resp_cfg.mask = DefaultFilterServiceMask;
     if (multiset_configs_.emplace(service_resp_cfg) == NULL)
     {
         return -ErrMemory;
@@ -30,28 +42,13 @@ int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration()
     while (p)
     {
         CanFilterConfig cfg;
-        cfg.id = static_cast<uint32_t>(p->getDataTypeDescriptor().getID().get()) << 16;
-        cfg.id |= static_cast<uint32_t>(p->getDataTypeDescriptor().getKind()) << 8;
+        cfg.id = static_cast<uint32_t>(p->getDataTypeDescriptor().getID().get()) << 8;
         cfg.mask = DefaultFilterMsgMask;
         if (multiset_configs_.emplace(cfg) == NULL)
         {
             return -ErrMemory;
         }
         p = p->getNextListNode();
-    }
-
-    const TransferListenerBase* p1 = node_.getDispatcher().getListOfServiceRequestListeners().get();
-    while (p1)
-    {
-        CanFilterConfig cfg;
-        cfg.id = DefaultFilterServiceRequestID;
-        cfg.id |= static_cast<uint32_t>(p1->getDataTypeDescriptor().getID().get()) << 17;
-        cfg.mask = DefaultFilterServiceRequestMask;
-        if (multiset_configs_.emplace(cfg) == NULL)
-        {
-            return -ErrMemory;
-        }
-        p1 = p1->getNextListNode();
     }
 
     if (multiset_configs_.getSize() == 0)
@@ -152,7 +149,7 @@ int16_t CanAcceptanceFilterConfigurator::applyConfiguration(void)
     return 0;
 }
 
-int CanAcceptanceFilterConfigurator::configureFilters()
+int CanAcceptanceFilterConfigurator::configureFilters(AnonMassagePresence mode)
 {
     if (getNumFilters() == 0)
     {
@@ -160,7 +157,7 @@ int CanAcceptanceFilterConfigurator::configureFilters()
         return -ErrDriver;
     }
 
-    int16_t fill_array_error = loadInputConfiguration();
+    int16_t fill_array_error = loadInputConfiguration(mode);
     if (fill_array_error != 0)
     {
         UAVCAN_TRACE("CanAcceptanceFilter::loadInputConfiguration", "Failed to execute loadInputConfiguration()");

--- a/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
+++ b/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
@@ -14,7 +14,7 @@ const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceMask;
 const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgMask;
 const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgID;
 
-int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration(AnonMassagePresence load_mode)
+int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration(AnonMessagePresence load_mode)
 {
     multiset_configs_.clear();
 
@@ -149,7 +149,7 @@ int16_t CanAcceptanceFilterConfigurator::applyConfiguration(void)
     return 0;
 }
 
-int CanAcceptanceFilterConfigurator::configureFilters(AnonMassagePresence mode)
+int CanAcceptanceFilterConfigurator::configureFilters(AnonMessagePresence mode)
 {
     if (getNumFilters() == 0)
     {

--- a/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
+++ b/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
@@ -14,11 +14,11 @@ const unsigned CanAcceptanceFilterConfigurator::DefaultFilterServiceMask;
 const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgMask;
 const unsigned CanAcceptanceFilterConfigurator::DefaultAnonMsgID;
 
-int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration(AnonMessagePresence load_mode)
+int16_t CanAcceptanceFilterConfigurator::loadInputConfiguration(AnonymousMessages load_mode)
 {
     multiset_configs_.clear();
 
-    if (load_mode == WithAnonMsg)
+    if (load_mode == AcceptAnonymousMessages)
     {
         CanFilterConfig anon_frame_cfg;
         anon_frame_cfg.id = DefaultAnonMsgID;
@@ -149,7 +149,7 @@ int16_t CanAcceptanceFilterConfigurator::applyConfiguration(void)
     return 0;
 }
 
-int CanAcceptanceFilterConfigurator::configureFilters(AnonMessagePresence mode)
+int CanAcceptanceFilterConfigurator::configureFilters(AnonymousMessages mode)
 {
     if (getNumFilters() == 0)
     {

--- a/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
+++ b/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
@@ -19,10 +19,7 @@
 #include <uavcan/node/service_client.hpp>
 #include <uavcan/node/service_server.hpp>
 #include <iostream>
-#include <bitset>
 
-// TODO FIXME: Requires update
-#if 0
 #if UAVCAN_CPP_VERSION >= UAVCAN_CPP11
 
 template <typename DataType>
@@ -128,14 +125,15 @@ TEST(CanAcceptanceFilter, Basic_test)
     server.start(writeServiceServerCallback);
     std::cout << "Subscribers are initialized ..." << std::endl;
 
-    uavcan::CanAcceptanceFilterConfigurator test_configurator(node);
-    int configure_filters_assert = test_configurator.configureFilters();
+
+    uavcan::CanAcceptanceFilterConfigurator anon_test_configuration(node);
+    int configure_filters_assert = anon_test_configuration.configureFilters();
     if (configure_filters_assert == 0)
     {
-        std::cout << "Filters are configured ..." << std::endl;
+        std::cout << "Filters are configured with anonymous configuration..." << std::endl;
     }
 
-    const auto& configure_array = test_configurator.getConfiguration();
+    const auto& configure_array = anon_test_configuration.getConfiguration();
     uint32_t configure_array_size = configure_array.getSize();
 
     ASSERT_EQ(configure_filters_assert, 0);
@@ -147,14 +145,41 @@ TEST(CanAcceptanceFilter, Basic_test)
         std::cout << "config.MK [" << i << "]= " << configure_array.getByIndex(i)->mask << std::endl;
     }
 
-    ASSERT_EQ(configure_array.getByIndex(0)->id, 268435456);
-    ASSERT_EQ(configure_array.getByIndex(0)->mask, 469762048);
-    ASSERT_EQ(configure_array.getByIndex(1)->id, 363069440);
-    ASSERT_EQ(configure_array.getByIndex(1)->mask, 536739840);
-    ASSERT_EQ(configure_array.getByIndex(2)->id, 16777216);
-    ASSERT_EQ(configure_array.getByIndex(2)->mask, 124452864);
-    ASSERT_EQ(configure_array.getByIndex(3)->id, 18874368);
-    ASSERT_EQ(configure_array.getByIndex(3)->mask, 133169152);
+    ASSERT_EQ(configure_array.getByIndex(0)->id, 0);
+    ASSERT_EQ(configure_array.getByIndex(0)->mask, 15);
+    ASSERT_EQ(configure_array.getByIndex(1)->id, 256000);
+    ASSERT_EQ(configure_array.getByIndex(1)->mask, 16771968);
+    ASSERT_EQ(configure_array.getByIndex(2)->id, 6272);
+    ASSERT_EQ(configure_array.getByIndex(2)->mask, 32640);
+    ASSERT_EQ(configure_array.getByIndex(3)->id, 262144);
+    ASSERT_EQ(configure_array.getByIndex(3)->mask, 16771200);
+
+
+    uavcan::CanAcceptanceFilterConfigurator no_anon_test_confiruration(node);
+    configure_filters_assert = no_anon_test_confiruration.configureFilters(uavcan::NoAnonMsg);
+    if (configure_filters_assert == 0)
+    {
+        std::cout << "Filters are configured without anonymous configuration..."<< std::endl;
+    }
+    const auto& configure_array_2 = no_anon_test_confiruration.getConfiguration();
+    configure_array_size = configure_array_2.getSize();
+
+    ASSERT_EQ(configure_filters_assert, 0);
+    ASSERT_EQ(configure_array_size, 4);
+
+    for (uint16_t i = 0; i<configure_array_size; i++)
+    {
+        std::cout << "config.ID [" << i << "]= " << configure_array.getByIndex(i)->id << std::endl;
+        std::cout << "config.MK [" << i << "]= " << configure_array.getByIndex(i)->mask << std::endl;
+    }
+
+    ASSERT_EQ(configure_array_2.getByIndex(0)->id, 6272);
+    ASSERT_EQ(configure_array_2.getByIndex(0)->mask, 32640);
+    ASSERT_EQ(configure_array_2.getByIndex(1)->id, 262144);
+    ASSERT_EQ(configure_array_2.getByIndex(1)->mask, 16776320);
+    ASSERT_EQ(configure_array_2.getByIndex(2)->id, 256000);
+    ASSERT_EQ(configure_array_2.getByIndex(2)->mask, 16771968);
+    ASSERT_EQ(configure_array_2.getByIndex(3)->id, 262144);
+    ASSERT_EQ(configure_array_2.getByIndex(3)->mask, 16771968);
 }
-#endif
 #endif

--- a/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
+++ b/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
@@ -156,10 +156,11 @@ TEST(CanAcceptanceFilter, Basic_test)
 
 
     uavcan::CanAcceptanceFilterConfigurator no_anon_test_confiruration(node);
-    configure_filters_assert = no_anon_test_confiruration.configureFilters(uavcan::NoAnonMsg);
+    configure_filters_assert = no_anon_test_confiruration.configureFilters
+                                   (uavcan::CanAcceptanceFilterConfigurator::NoAnonMsg);
     if (configure_filters_assert == 0)
     {
-        std::cout << "Filters are configured without anonymous configuration..."<< std::endl;
+        std::cout << "Filters are configured without anonymous configuration..." << std::endl;
     }
     const auto& configure_array_2 = no_anon_test_confiruration.getConfiguration();
     configure_array_size = configure_array_2.getSize();

--- a/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
+++ b/libuavcan/test/transport/can_acceptance_filter_configurator.cpp
@@ -146,7 +146,7 @@ TEST(CanAcceptanceFilter, Basic_test)
     }
 
     ASSERT_EQ(configure_array.getByIndex(0)->id, 0);
-    ASSERT_EQ(configure_array.getByIndex(0)->mask, 15);
+    ASSERT_EQ(configure_array.getByIndex(0)->mask, 255);
     ASSERT_EQ(configure_array.getByIndex(1)->id, 256000);
     ASSERT_EQ(configure_array.getByIndex(1)->mask, 16771968);
     ASSERT_EQ(configure_array.getByIndex(2)->id, 6272);
@@ -157,7 +157,7 @@ TEST(CanAcceptanceFilter, Basic_test)
 
     uavcan::CanAcceptanceFilterConfigurator no_anon_test_confiruration(node);
     configure_filters_assert = no_anon_test_confiruration.configureFilters
-                                   (uavcan::CanAcceptanceFilterConfigurator::NoAnonMsg);
+                                   (uavcan::CanAcceptanceFilterConfigurator::IgnoreAnonymousMessages);
     if (configure_filters_assert == 0)
     {
         std::cout << "Filters are configured without anonymous configuration..." << std::endl;


### PR DESCRIPTION
I made enum AnonMassagePresence {WithAnonMsg,NoAnonMsg}; as input argument for configureFilters func for explicity.
Also added another case in unit tests for non-anonymous configuration.