### PR TITLE
Adds Nuttx Support to uc_stm32_clock

### DIFF
--- a/libuavcan_drivers/stm32/driver/include/uavcan_stm32/clock.hpp
+++ b/libuavcan_drivers/stm32/driver/include/uavcan_stm32/clock.hpp
@@ -25,6 +25,14 @@ void init();
 uavcan::MonotonicTime getMonotonic();
 
 /**
+ * Sets the driver's notion of the system UTC. It should be called
+ * at startup and any time the system clock is updated from an
+ * external source that is not the UAVCAN Timesync master.
+ * This function is thread safe.
+ */
+void setUtc(uavcan::UtcTime time);
+
+/**
  * Returns UTC time if it has been set, otherwise returns zero time.
  * This function is thread safe.
  */

--- a/libuavcan_drivers/stm32/driver/include/uavcan_stm32/thread.hpp
+++ b/libuavcan_drivers/stm32/driver/include/uavcan_stm32/thread.hpp
@@ -24,7 +24,6 @@
 
 namespace uavcan_stm32
 {
-
 class CanDriver;
 
 #if UAVCAN_STM32_CHIBIOS
@@ -92,6 +91,54 @@ public:
     void signalFromInterrupt();
 };
 
+class Mutex
+{
+    pthread_mutex_t mutex_;
+
+public:
+    Mutex()
+    {
+        init();
+    }
+
+    int init()
+    {
+        return pthread_mutex_init(&mutex_, NULL);
+    }
+
+    int deinit()
+    {
+        return pthread_mutex_destroy(&mutex_);
+    }
+
+    void lock()
+    {
+        (void)pthread_mutex_lock(&mutex_);
+    }
+
+    void unlock()
+    {
+        (void)pthread_mutex_unlock(&mutex_);
+    }
+};
+
+class MutexLocker
+{
+    Mutex& mutex_;
+
+public:
+    MutexLocker(Mutex& mutex)
+        : mutex_(mutex)
+    {
+        mutex_.lock();
+    }
+
+    ~MutexLocker()
+    {
+        mutex_.unlock();
+    }
+};
+
 #endif
 
 
@@ -107,6 +154,7 @@ public:
     {
         mutex_.lock();
     }
+
     ~MutexLocker()
     {
         mutex_.unlock();
@@ -114,5 +162,4 @@ public:
 };
 
 #endif
-
 }

--- a/libuavcan_drivers/stm32/driver/src/internal.hpp
+++ b/libuavcan_drivers/stm32/driver/src/internal.hpp
@@ -10,6 +10,8 @@
 # include <hal.h>
 #elif UAVCAN_STM32_NUTTX
 # include <nuttx/arch.h>
+# include <arch/board/board.h>
+# include <chip/stm32_tim.h>
 # include <syslog.h>
 #else
 # error "Unknown OS"
@@ -20,7 +22,7 @@
  */
 #ifndef UAVCAN_STM32_LOG
 // lowsyslog() crashes the system in this context
-//# if UAVCAN_STM32_NUTTX && CONFIG_ARCH_LOWPUTC
+// # if UAVCAN_STM32_NUTTX && CONFIG_ARCH_LOWPUTC
 # if 0
 #  define UAVCAN_STM32_LOG(fmt, ...)  lowsyslog("uavcan_stm32: " fmt "\n", ##__VA_ARGS__)
 # else
@@ -36,13 +38,14 @@
 # define UAVCAN_STM32_IRQ_HANDLER(id)  CH_IRQ_HANDLER(id)
 # define UAVCAN_STM32_IRQ_PROLOGUE()    CH_IRQ_PROLOGUE()
 # define UAVCAN_STM32_IRQ_EPILOGUE()    CH_IRQ_EPILOGUE()
-
+#elif UAVCAN_STM32_NUTTX
+# define UAVCAN_STM32_IRQ_HANDLER(id)  int id(int irq, FAR void* context)
+# define UAVCAN_STM32_IRQ_PROLOGUE()
+# define UAVCAN_STM32_IRQ_EPILOGUE()    return 0;
 #else
-
 # define UAVCAN_STM32_IRQ_HANDLER(id)  void id(void)
 # define UAVCAN_STM32_IRQ_PROLOGUE()
 # define UAVCAN_STM32_IRQ_EPILOGUE()
-
 #endif
 
 #if UAVCAN_STM32_CHIBIOS
@@ -65,7 +68,6 @@
 
 namespace uavcan_stm32
 {
-
 #if UAVCAN_STM32_CHIBIOS
 
 struct CriticalSectionLocker
@@ -94,9 +96,6 @@ struct CriticalSectionLocker
 
 namespace clock
 {
-
 uavcan::uint64_t getUtcUSecFromCanInterrupt();
-
 }
-
 }

--- a/libuavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
+++ b/libuavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
@@ -124,7 +124,9 @@ void init()
     putreg16(BTIM_CR1_CEN, TMR_REG(STM32_BTIM_CR1_OFFSET)); // Start
 
     // Prioritize and Enable  IRQ
-    up_prioritize_irq(TIMX_IRQn, NVIC_SYSH_HIGH_PRIORITY);
+// todo: Currently changing the NVIC_SYSH_HIGH_PRIORITY is HARD faulting
+// need to investigate
+//    up_prioritize_irq(TIMX_IRQn, NVIC_SYSH_HIGH_PRIORITY);
     up_enable_irq(TIMX_IRQn);
 
 # endif


### PR DESCRIPTION
@pavel-kirienko 

This adds the support needed for Nuttx to facilitate the UAVCAN Time synchronization.