### PR TITLE
Add UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY flag

### DIFF
--- a/libuavcan/include/uavcan/build_config.hpp
+++ b/libuavcan/include/uavcan/build_config.hpp
@@ -104,7 +104,7 @@
  * Disable the global data type registry, which can save some space on embedded systems.
  */
 #ifndef UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY
-# define UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY 1
+# define UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY 0
 #endif
 
 /**

--- a/libuavcan/include/uavcan/build_config.hpp
+++ b/libuavcan/include/uavcan/build_config.hpp
@@ -101,6 +101,13 @@
 #endif
 
 /**
+ * Disable the global data type registry, which can save some space on embedded systems.
+ */
+#ifndef UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY
+# define UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY 1
+#endif
+
+/**
  * toString() methods will be disabled by default, unless the library is built for a general-purpose target like Linux.
  * It is not recommended to enable toString() on embedded targets as code size will explode.
  */

--- a/libuavcan/include/uavcan/node/global_data_type_registry.hpp
+++ b/libuavcan/include/uavcan/node/global_data_type_registry.hpp
@@ -187,6 +187,7 @@ struct UAVCAN_EXPORT DefaultDataTypeRegistrator
 {
     DefaultDataTypeRegistrator()
     {
+#if !UAVCAN_NO_GLOBAL_DATA_TYPE_REGISTRY
         const GlobalDataTypeRegistry::RegistrationResult res =
             GlobalDataTypeRegistry::instance().registerDataType<Type>(Type::DefaultDataTypeID);
 
@@ -194,6 +195,7 @@ struct UAVCAN_EXPORT DefaultDataTypeRegistrator
         {
             handleFatalError("Type reg failed");
         }
+#endif
     }
 };
 


### PR DESCRIPTION
This allows the global data type registry to be disabled if it's not needed, saving 2–4 KiB depending on compilation settings and the data types used.