### PR TITLE
Changed NodeInfoRetriever to inherit publicly from NodeStatusMonitor 

### DIFF
--- a/libuavcan/include/uavcan/protocol/node_info_retriever.hpp
+++ b/libuavcan/include/uavcan/protocol/node_info_retriever.hpp
@@ -88,7 +88,7 @@ public:
  *
  * Events from this class can be routed to many listeners, @ref INodeInfoListener.
  */
-class UAVCAN_EXPORT NodeInfoRetriever : NodeStatusMonitor
+class UAVCAN_EXPORT NodeInfoRetriever : public NodeStatusMonitor
                                       , TimerBase
 {
 public:


### PR DESCRIPTION
Allows access to node status API (`isNodeKnown`, `getNodeStatus` etc) from `NodeInfoRetriever` instances.