### PR TITLE
Refactored SocketCAN select() call; fixes #83

### DIFF
--- a/libuavcan_drivers/linux/CMakeLists.txt
+++ b/libuavcan_drivers/linux/CMakeLists.txt
@@ -45,6 +45,10 @@ endif ()
 include_directories(include)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -std=c++11")  # GCC or Clang
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions(-DUAVCAN_DEBUG=1)
+endif()
+
 #
 # Tests
 # These aren't installed, an average library user should not care about them.

--- a/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
+++ b/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
@@ -17,15 +17,15 @@ class Exception : public std::runtime_error
 {
     const int errno_;
 
-    static std::string makeErrorString(const std::string& descr)
+    static std::string makeErrorString(const std::string& descr, int use_errno)
     {
-        return descr + " [errno " + std::to_string(errno) + " \"" + std::strerror(errno) + "\"]";
+        return descr + " [errno " + std::to_string(use_errno) + " \"" + std::strerror(use_errno) + "\"]";
     }
 
 public:
-    explicit Exception(const std::string& descr)
-        : std::runtime_error(makeErrorString(descr))
-        , errno_(errno)
+    explicit Exception(const std::string& descr, int use_errno = errno)
+        : std::runtime_error(makeErrorString(descr, use_errno))
+        , errno_(use_errno)
     { }
 
     /**
@@ -41,7 +41,7 @@ public:
 class AllIfacesDownException : public Exception
 {
 public:
-    AllIfacesDownException() : Exception("All ifaces are down") { }
+    AllIfacesDownException() : Exception("All ifaces are down", ENETDOWN) { }
 };
 
 }

--- a/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
+++ b/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cerrno>
+#include <cstring>
 #include <stdexcept>
 
 namespace uavcan_linux
@@ -16,9 +17,14 @@ class Exception : public std::runtime_error
 {
     const int errno_;
 
+    static std::string makeErrorString(const std::string& descr)
+    {
+        return descr + " [errno " + std::to_string(errno) + " \"" + std::strerror(errno) + "\"]";
+    }
+
 public:
     explicit Exception(const std::string& descr)
-        : std::runtime_error(descr)
+        : std::runtime_error(makeErrorString(descr))
         , errno_(errno)
     { }
 

--- a/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
+++ b/libuavcan_drivers/linux/include/uavcan_linux/exception.hpp
@@ -29,4 +29,13 @@ public:
     int getErrno() const { return errno_; }
 };
 
+/**
+ * This exception is thrown when all available interfaces become down.
+ */
+class AllIfacesDownException : public Exception
+{
+public:
+    AllIfacesDownException() : Exception("All ifaces are down") { }
+};
+
 }

--- a/libuavcan_drivers/linux/include/uavcan_linux/socketcan.hpp
+++ b/libuavcan_drivers/linux/include/uavcan_linux/socketcan.hpp
@@ -607,6 +607,12 @@ public:
 /**
  * Multiplexing container for multiple SocketCAN sockets.
  * Uses ppoll() for multiplexing.
+ *
+ * When an interface becomes down/disconnected while the node is running,
+ * the driver will silently exclude it from the IO loop and continue to run on the remaining interfaces.
+ * When all interfaces become down/disconnected, the driver will throw @ref AllIfacesDownException
+ * from @ref SocketCanDriver::select().
+ * Whether a certain interface is down can be checked with @ref SocketCanDriver::isIfaceDown().
  */
 class SocketCanDriver : public uavcan::ICanDriver
 {


### PR DESCRIPTION
Features:
- The driver will throw if it's fed a non-existing or malfunctioning interface during initialization.
- When an interface becomes down/disconnected while the node is running, the driver will silently
  exclude it from the IO loop and continue to run on the remaining interfaces.
- When all interfaces become down/disconnected, the driver will throw `AllIfacesDownException` from
  `SocketCanDriver::select()`.

I will merge it myself.