### PR TITLE
Monitoring activity of dynamic node ID allocation servers

### DIFF
--- a/libuavcan/include/uavcan/protocol/dynamic_node_id_server/abstract_server.hpp
+++ b/libuavcan/include/uavcan/protocol/dynamic_node_id_server/abstract_server.hpp
@@ -67,7 +67,8 @@ public:
      */
     bool guessIfAllDynamicNodesAreAllocated(
         const MonotonicDuration& allocation_activity_timeout =
-            MonotonicDuration::fromMSec(protocol::NodeStatus::OFFLINE_TIMEOUT_MS)) const
+            MonotonicDuration::fromMSec(Allocation::MAX_REQUEST_PERIOD_MS * 2),
+        const MonotonicDuration& min_uptime = MonotonicDuration::fromMSec(6000)) const
     {
         const MonotonicTime ts = node_.getMonotonicTime();
 
@@ -75,7 +76,7 @@ public:
          * If uptime is not large enough, the allocator may be unaware about some nodes yet.
          */
         const MonotonicDuration uptime = ts - started_at_;
-        if (uptime < allocation_activity_timeout)
+        if (uptime < max(allocation_activity_timeout, min_uptime))
         {
             return false;
         }

--- a/libuavcan/include/uavcan/protocol/dynamic_node_id_server/abstract_server.hpp
+++ b/libuavcan/include/uavcan/protocol/dynamic_node_id_server/abstract_server.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Pavel Kirienko <pavel.kirienko@gmail.com>
+ */
+
+#ifndef UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_SERVER_SERVER_HPP_INCLUDED
+#define UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_SERVER_SERVER_HPP_INCLUDED
+
+#include <uavcan/build_config.hpp>
+#include <uavcan/debug.hpp>
+#include <uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp>
+#include <uavcan/protocol/dynamic_node_id_server/node_discoverer.hpp>
+#include <uavcan/protocol/dynamic_node_id_server/event.hpp>
+
+namespace uavcan
+{
+namespace dynamic_node_id_server
+{
+
+class AbstractServer : protected IAllocationRequestHandler
+                     , protected INodeDiscoveryHandler
+{
+    UniqueID own_unique_id_;
+
+protected:
+    INode& node_;
+    IEventTracer& tracer_;
+    AllocationRequestManager allocation_request_manager_;
+    NodeDiscoverer node_discoverer_;
+
+    AbstractServer(INode& node,
+                   IEventTracer& tracer) :
+       node_(node),
+       tracer_(tracer),
+       allocation_request_manager_(node, tracer, *this),
+       node_discoverer_(node, tracer, *this)
+    { }
+
+    const UniqueID& getOwnUniqueID() const { return own_unique_id_; }
+
+    int init(const UniqueID& own_unique_id, const TransferPriority priority)
+    {
+        int res = 0;
+
+        own_unique_id_ = own_unique_id;
+
+        res = allocation_request_manager_.init(priority);
+        if (res < 0)
+        {
+            return res;
+        }
+
+        res = node_discoverer_.init(priority);
+        if (res < 0)
+        {
+            return res;
+        }
+
+        return 0;
+    }
+
+public:
+    const NodeDiscoverer& getNodeDiscoverer() const { return node_discoverer_; }
+};
+
+}
+}
+
+#endif // Include guard

--- a/libuavcan/include/uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp
+++ b/libuavcan/include/uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp
@@ -268,6 +268,7 @@ public:
         msg.node_id = allocated_node_id.get();
 
         trace(TraceAllocationResponse, msg.node_id);
+        last_activity_timestamp_ = allocation_pub_.getNode().getMonotonicTime();
 
         return allocation_pub_.broadcast(msg);
     }

--- a/libuavcan/include/uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp
+++ b/libuavcan/include/uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp
@@ -51,6 +51,7 @@ class AllocationRequestManager
     const MonotonicDuration stage_timeout_;
 
     MonotonicTime last_message_timestamp_;
+    MonotonicTime last_activity_timestamp_;
     Allocation::FieldTypes::unique_id current_unique_id_;
 
     IAllocationRequestHandler& handler_;
@@ -127,6 +128,7 @@ class AllocationRequestManager
     void handleAllocation(const ReceivedDataStructure<Allocation>& msg)
     {
         trace(TraceAllocationActivity, msg.getSrcNodeID().get());
+        last_activity_timestamp_ = msg.getMonotonicTimestamp();
 
         if (!msg.isAnonymousTransfer())
         {
@@ -269,6 +271,12 @@ public:
 
         return allocation_pub_.broadcast(msg);
     }
+
+    /**
+     * When the last allocation activity was registered.
+     * This value can be used to heuristically determine whether there are any unallocated nodes left in the network.
+     */
+    MonotonicTime getTimeOfLastAllocationActivity() const { return last_activity_timestamp_; }
 };
 
 }

--- a/libuavcan/include/uavcan/protocol/dynamic_node_id_server/centralized/server.hpp
+++ b/libuavcan/include/uavcan/protocol/dynamic_node_id_server/centralized/server.hpp
@@ -7,8 +7,7 @@
 
 #include <uavcan/build_config.hpp>
 #include <uavcan/debug.hpp>
-#include <uavcan/protocol/dynamic_node_id_server/allocation_request_manager.hpp>
-#include <uavcan/protocol/dynamic_node_id_server/node_discoverer.hpp>
+#include <uavcan/protocol/dynamic_node_id_server/abstract_server.hpp>
 #include <uavcan/protocol/dynamic_node_id_server/node_id_selector.hpp>
 #include <uavcan/protocol/dynamic_node_id_server/storage_marshaller.hpp>
 #include <uavcan/protocol/dynamic_node_id_server/centralized/storage.hpp>
@@ -26,15 +25,8 @@ namespace centralized
  *
  * This version is suitable only for simple non-critical systems.
  */
-class Server : IAllocationRequestHandler
-             , INodeDiscoveryHandler
+class Server : public AbstractServer
 {
-    UniqueID own_unique_id_;
-
-    INode& node_;
-    IEventTracer& tracer_;
-    AllocationRequestManager allocation_request_manager_;
-    NodeDiscoverer node_discoverer_;
     Storage storage_;
 
     /*
@@ -128,10 +120,7 @@ public:
     Server(INode& node,
            IStorageBackend& storage,
            IEventTracer& tracer)
-        : node_(node)
-        , tracer_(tracer)
-        , allocation_request_manager_(node, tracer, *this)
-        , node_discoverer_(node, tracer, *this)
+        : AbstractServer(node, tracer)
         , storage_(storage)
     { }
 
@@ -148,12 +137,19 @@ public:
         }
 
         /*
+         * Common logic
+         */
+        res = AbstractServer::init(own_unique_id, priority);
+        if (res < 0)
+        {
+            return res;
+        }
+
+        /*
          * Making sure that the server is started with the same node ID
          */
-        own_unique_id_ = own_unique_id;
-
         {
-            const NodeID stored_own_node_id = storage_.getNodeIDForUniqueID(own_unique_id_);
+            const NodeID stored_own_node_id = storage_.getNodeIDForUniqueID(getOwnUniqueID());
             if (stored_own_node_id.isValid())
             {
                 if (stored_own_node_id != node_.getNodeID())
@@ -163,27 +159,12 @@ public:
             }
             else
             {
-                res = storage_.add(node_.getNodeID(), own_unique_id_);
+                res = storage_.add(node_.getNodeID(), getOwnUniqueID());
                 if (res < 0)
                 {
                     return res;
                 }
             }
-        }
-
-        /*
-         * Misc
-         */
-        res = allocation_request_manager_.init(priority);
-        if (res < 0)
-        {
-            return res;
-        }
-
-        res = node_discoverer_.init(priority);
-        if (res < 0)
-        {
-            return res;
         }
 
         return 0;

--- a/libuavcan_drivers/linux/apps/uavcan_dynamic_node_id_server.cpp
+++ b/libuavcan_drivers/linux/apps/uavcan_dynamic_node_id_server.cpp
@@ -256,7 +256,7 @@ void redraw(const uavcan_linux::NodePtr& node,
     /*
      * Constants that are permanent for the designed UI layout
      */
-    constexpr unsigned NumRelevantEvents = 16;
+    constexpr unsigned NumRelevantEvents = 17;
     constexpr unsigned NumRowsWithoutEvents = 3;
 
     /*
@@ -389,6 +389,11 @@ void redraw(const uavcan_linux::NodePtr& node,
     render_top_int("Node failures",
                    node->getInternalFailureCount(),
                    colorize_if(node->getInternalFailureCount() != 0, CLIColor::Magenta));
+
+    const bool all_allocated = server.guessIfAllDynamicNodesAreAllocated();
+    render_top_str("All allocated",
+                   all_allocated ? "Yes": "No",
+                   colorize_if(!all_allocated, CLIColor::Magenta));
 
     // Empty line before the next block
     std::printf("                                     ");


### PR DESCRIPTION
This change adds new API to the dynamic node ID allocation server that allows to guess if dynamic node ID allocation is finished. With this information, APM will be able to reduce the UAVCAN sensor initialization delay to the bare minimum. This PR also brings some minor collateral refactoring (see commit messages).

The changes have been tested on Linux successfully, and the PR is ready for merge.

@hsteinhaus