### PR TITLE
Do not merge - This is needed to work with the latest upstream nuttx

### DIFF
--- a/libuavcan_drivers/stm32/driver/src/internal.hpp
+++ b/libuavcan_drivers/stm32/driver/src/internal.hpp
@@ -97,12 +97,12 @@ struct CriticalSectionLocker
     const irqstate_t flags_;
 
     CriticalSectionLocker()
-        : flags_(irqsave())
+        : flags_(enter_critical_section())
     { }
 
     ~CriticalSectionLocker()
     {
-        irqrestore(flags_);
+        leave_critical_section(flags_);
     }
 };
 


### PR DESCRIPTION
@pavel-kirienko 

I would have liked to push this to your repo on a branch that I can reference as a submodule of the next nuttx_next_cmake_update branch of px4 Firmware. It can not be mainlined yet because we're not ready for it yet.


