### PR TITLE
Do Not merge - This is needed to work with the latest upstream nuttx

### DIFF
--- a/libuavcan_drivers/stm32/driver/src/internal.hpp
+++ b/libuavcan_drivers/stm32/driver/src/internal.hpp
@@ -97,12 +97,12 @@ struct CriticalSectionLocker
     const irqstate_t flags_;
 
     CriticalSectionLocker()
-        : flags_(irqsave())
+        : flags_(enter_critical_section())
     { }
 
     ~CriticalSectionLocker()
     {
-        irqrestore(flags_);
+        leave_critical_section(flags_);
     }
 };
 


### PR DESCRIPTION
@pavel-kirienko 

This is just a second place holder on top of the latest version PX4 is using of libuavcan on their master to build with upstream nuttx 
