### PR TITLE
Minor fixes: unnecessary sign conversion, redundant path delimiter.

### DIFF
--- a/libuavcan/include.mk
+++ b/libuavcan/include.mk
@@ -21,4 +21,4 @@ LIBUAVCAN_DSDLC := $(LIBUAVCAN_DIR)dsdl_compiler/libuavcan_dsdlc
 #
 # Standard DSDL definitions
 #
-UAVCAN_DSDL_DIR := $(UAVCAN_DIR)/dsdl/uavcan
+UAVCAN_DSDL_DIR := $(UAVCAN_DIR)dsdl/uavcan

--- a/libuavcan/src/marshal/uc_bit_stream.cpp
+++ b/libuavcan/src/marshal/uc_bit_stream.cpp
@@ -84,7 +84,7 @@ std::string BitStream::toString() const
     for (unsigned offset = 0; true; offset++)
     {
         uint8_t byte = 0;
-        if (1U != buf_.read(offset, &byte, 1U))
+        if (1 != buf_.read(offset, &byte, 1U))
         {
             break;
         }


### PR DESCRIPTION
Build failed with -Wsign-conversion -Werror.  The offending conversion isn't necessary since it's testing equality to positive-one.

The redundant path delimiter is not a bug, more a minor style issue.  Feel free to ignore that commit.