### PR TITLE
Rename variable "ch" to "chr" to avoid shadow variable in ChibiOS

### DIFF
--- a/libuavcan/include/uavcan/marshal/array.hpp
+++ b/libuavcan/include/uavcan/marshal/array.hpp
@@ -809,13 +809,13 @@ public:
      * This operator can only be used with string-like arrays; otherwise it will fail to compile.
      * @ref c_str()
      */
-    bool operator==(const char* ch) const
+    bool operator==(const char* chr) const
     {
-        if (ch == UAVCAN_NULLPTR)
+        if (chr == UAVCAN_NULLPTR)
         {
             return false;
         }
-        return std::strncmp(Base::c_str(), ch, MaxSize) == 0;
+        return std::strncmp(Base::c_str(), chr, MaxSize) == 0;
     }
 
     /**
@@ -827,18 +827,18 @@ public:
      * This operator can only be used with string-like arrays; otherwise it will fail to compile.
      * @ref c_str()
      */
-    SelfType& operator=(const char* ch)
+    SelfType& operator=(const char* chr)
     {
         StaticAssert<Base::IsStringLike>::check();
         StaticAssert<IsDynamic>::check();
         Base::clear();
-        if (ch == UAVCAN_NULLPTR)
+        if (chr == UAVCAN_NULLPTR)
         {
             handleFatalError("Array::operator=(const char*)");
         }
-        while (*ch)
+        while (*chr)
         {
-            push_back(ValueType(*ch++));  // Value type is likely to be unsigned char, so conversion may be required.
+            push_back(ValueType(*chr++));  // Value type is likely to be unsigned char, so conversion may be required.
         }
         return *this;
     }
@@ -847,17 +847,17 @@ public:
      * This operator can only be used with string-like arrays; otherwise it will fail to compile.
      * @ref c_str()
      */
-    SelfType& operator+=(const char* ch)
+    SelfType& operator+=(const char* chr)
     {
         StaticAssert<Base::IsStringLike>::check();
         StaticAssert<IsDynamic>::check();
-        if (ch == UAVCAN_NULLPTR)
+        if (chr == UAVCAN_NULLPTR)
         {
             handleFatalError("Array::operator+=(const char*)");
         }
-        while (*ch)
+        while (*chr)
         {
-            push_back(ValueType(*ch++));
+            push_back(ValueType(*chr++));
         }
         return *this;
     }


### PR DESCRIPTION
Rename variable "ch" to "chr" to avoid shadow variable in ChibiOS. There is a global variable in ChibiOS called "ch" so when a local variable in UAVCAN is called the same name there is a shadowing compile warning. It's never a real conflict but it causes a bunch of compiler warnings. Simply renaming the local variable solves it.