### PR TITLE
DSDL union tag code generation bug fix

### DIFF
--- a/libuavcan/dsdl_compiler/libuavcan_dsdl_compiler/data_type_template.tmpl
+++ b/libuavcan/dsdl_compiler/libuavcan_dsdl_compiler/data_type_template.tmpl
@@ -70,7 +70,7 @@ struct UAVCAN_EXPORT ${t.cpp_type_name}
         };
     };
 
-    typedef ::uavcan::IntegerSpec< ::uavcan::IntegerBitLen< ${len(fields)} >::Result,
+    typedef ::uavcan::IntegerSpec< ::uavcan::IntegerBitLen< ${len(fields)}U - 1U >::Result,
                                    ::uavcan::SignednessUnsigned, ::uavcan::CastModeTruncate > TagType;
 
         <!--(macro expand_enum_per_field)--> #! enum_name, enum_comparator

--- a/libuavcan/test/dsdl_test/dsdl_uavcan_compilability.cpp
+++ b/libuavcan/test/dsdl_test/dsdl_uavcan_compilability.cpp
@@ -22,6 +22,7 @@
 
 #include <root_ns_a/Deep.hpp>
 #include <root_ns_a/UnionTest.hpp>
+#include <root_ns_a/UnionTest4.hpp>
 
 template <typename T>
 static bool validateYaml(const T& obj, const std::string& reference)
@@ -197,6 +198,38 @@ TEST(Dsdl, Union)
     s.to<UnionTest::Tag::e>().array[3] = 3;
     EXPECT_TRUE(validateYaml(s, "e: \n  array: [0, 1, 2, 3]"));
     EXPECT_TRUE(encodeDecodeValidate(s, "10100000 11011000"));
+}
+
+
+
+TEST(Dsdl, UnionTagWidth)
+{
+    using root_ns_a::UnionTest4;
+
+    ASSERT_EQ(2, UnionTest4::MinBitLen);
+    ASSERT_EQ(8, UnionTest4::MaxBitLen);
+
+    UnionTest4 s;
+
+    {
+        uavcan::StaticTransferBuffer<100> buf;
+        uavcan::BitStream bs_wr(buf);
+        uavcan::ScalarCodec sc_wr(bs_wr);
+
+        ASSERT_EQ(1, UnionTest4::encode(s, sc_wr));
+        ASSERT_EQ("00000000", bs_wr.toString());
+    }
+
+    {
+        uavcan::StaticTransferBuffer<100> buf;
+        uavcan::BitStream bs_wr(buf);
+        uavcan::ScalarCodec sc_wr(bs_wr);
+
+        s.to<UnionTest4::Tag::third>() = 1U << 5U;   // 32, 0b100000
+
+        ASSERT_EQ(1, UnionTest4::encode(s, sc_wr));
+        ASSERT_EQ("10100000", bs_wr.toString());
+    }
 }
 
 

--- a/libuavcan/test/dsdl_test/dsdl_uavcan_compilability.cpp
+++ b/libuavcan/test/dsdl_test/dsdl_uavcan_compilability.cpp
@@ -201,7 +201,6 @@ TEST(Dsdl, Union)
 }
 
 
-
 TEST(Dsdl, UnionTagWidth)
 {
     using root_ns_a::UnionTest4;

--- a/libuavcan/test/dsdl_test/root_ns_a/UnionTest4.uavcan
+++ b/libuavcan/test/dsdl_test/root_ns_a/UnionTest4.uavcan
@@ -1,0 +1,6 @@
+# A union of four items; tag 2 bits wide, total length 1 byte
+@union          # 2 bits
+Empty first     # Tag value 0
+uint5 second    # Tag value 1
+uint6 third     # Tag value 2
+int2  fourth    # Tag value 3


### PR DESCRIPTION
Report from Juha Kuikka @kuikka on [Gitter](https://gitter.im/UAVCAN/general) and the [mailing list](https://groups.google.com/d/msgid/uavcan/4df274d9-1822-41e1-bd95-03f1ba30d007%40googlegroups.com?utm_medium=email&utm_source=footer).

> I'm seeing what looks like a bug with unions in messages. This issue is visible when I am trying to communicate between libuavcan and pyuavcan. I have an union with 4 members but the tag comes out to 3 bits by libuavcan due to `typedef ::uavcan::IntegerSpec< ::uavcan::IntegerBitLen< 4 >::Result, ::uavcan::SignednessUnsigned, ::uavcan::CastModeTruncate > TagType;` this is because `IntegerBitLen<4>::Result` evaluates to 3, which makes the tag size. The python side seems to set it to 2 bits because incoming data is off by a bit.

Concerning this:

> The data_type_template.tmpl could be changed have a -1 but that would break @union with only one member.

Here's a relavant quote from the specification:

> Unions are required to have at least two fields.