### PR TITLE
#132 proper googletest dependency and fixes for unittests on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__
 .pydevproject
 .gdbinit
 
+# vsstudio code
+.vscode
+
 # libuavcan DSDL compiler default output directory
 dsdlc_generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
     - sudo apt-get update -qq
     - if [ "$CXX" = "g++" ]; then sudo apt-get install --force-yes -qq g++-4.8; fi
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-    - sudo apt-get install --force-yes libgtest-dev gcc-arm-none-eabi
-    - "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+    - sudo apt-get install --force-yes gcc-arm-none-eabi
 before_script: "mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCONTINUOUS_INTEGRATION_BUILD=1"
 script:
     - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "native" ]; then make ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(uavcan C CXX)
 
@@ -66,6 +66,42 @@ include_directories(
 #
 # DSDL definitions
 install(DIRECTORY dsdl DESTINATION share/uavcan)
+
+#
+# Googletest
+#
+if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+    # (Taken from googletest/README.md documentation)
+    # GTest executables
+    # Download and unpack googletest at configure time
+    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+    if(result)
+        message(WARNING "CMake step for googletest failed: ${result}")
+    else()
+        execute_process(COMMAND ${CMAKE_COMMAND} --build .
+            RESULT_VARIABLE result
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+        if(result)
+            message(WARNING "Build step for googletest failed: ${result}")
+        else()
+
+            # Prevent overriding the parent project's compiler/linker
+            # settings on Windows
+            set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+            # Add googletest directly to our build. This defines
+            # the gtest and gtest_main targets.
+            add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                            ${CMAKE_BINARY_DIR}/googletest-build
+                            EXCLUDE_FROM_ALL)
+
+            set(GTEST_FOUND ON)
+        endif()
+    endif()
+endif()
 
 #
 # Subdirectories

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           98a0d007d7092b72eea0e501bb9ad17908a1a036
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/libuavcan/CMakeLists.txt
+++ b/libuavcan/CMakeLists.txt
@@ -89,7 +89,6 @@ install(CODE "execute_process(COMMAND ${PYTHON} setup.py install --record instal
 #
 function(add_libuavcan_test name library flags) # Adds GTest executable and creates target to execute it every build
     find_package(Threads REQUIRED)
-    include_directories(${GTEST_INCLUDE_DIRS})
 
     file(GLOB_RECURSE TEST_CXX_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "test/*.cpp")
     add_executable(${name} ${TEST_CXX_FILES})
@@ -99,9 +98,11 @@ function(add_libuavcan_test name library flags) # Adds GTest executable and crea
         set_target_properties(${name} PROPERTIES COMPILE_FLAGS ${flags})
     endif ()
 
-    target_link_libraries(${name} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(${name} gmock_main)
     target_link_libraries(${name} ${library})
-    target_link_libraries(${name} rt)
+    if (${UAVCAN_PLATFORM} STREQUAL "linux")
+        target_link_libraries(${name} rt)
+    endif()
 
     # Tests run automatically upon successful build
     # If failing tests need to be investigated with debugger, use 'make --ignore-errors'
@@ -145,10 +146,8 @@ if (DEBUG_BUILD)
     set_target_properties(uavcan_optim PROPERTIES COMPILE_FLAGS ${optim_flags})
     add_dependencies(uavcan_optim libuavcan_dsdlc)
 
-    # GTest executables
-    find_package(GTest)
     if (GTEST_FOUND)
-        message(STATUS "GTest found, tests will be built and run [${GTEST_INCLUDE_DIRS}] [${GTEST_BOTH_LIBRARIES}]")
+        message(STATUS "GTest found, tests will be built and run.")
         add_libuavcan_test(libuavcan_test       uavcan       "")                 # Default
         add_libuavcan_test(libuavcan_test_cpp03 uavcan_cpp03 "${cpp03_flags}")   # C++03
         add_libuavcan_test(libuavcan_test_optim uavcan_optim "${optim_flags}")   # Max optimization

--- a/libuavcan/test/helpers/heap_based_pool_allocator.cpp
+++ b/libuavcan/test/helpers/heap_based_pool_allocator.cpp
@@ -4,13 +4,19 @@
 
 #include <gtest/gtest.h>
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
+#ifdef __linux__
 #include <malloc.h>
 
+#else
+#include <stdlib.h>
+#endif
 
 TEST(HeapBasedPoolAllocator, Basic)
 {
+#ifdef __linux__
     std::cout << ">>> HEAP BEFORE:" << std::endl;
     malloc_stats();
+#endif
 
     uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize> al(0xEEEE);
 
@@ -61,8 +67,10 @@ TEST(HeapBasedPoolAllocator, Basic)
     ASSERT_EQ(0, al.getNumReservedBlocks());
     ASSERT_EQ(0, al.getNumAllocatedBlocks());
 
+#ifdef __linux__
     std::cout << ">>> HEAP AFTER:" << std::endl;
     malloc_stats();
+#endif
 }
 
 
@@ -115,9 +123,11 @@ std::mutex RaiiSynchronizer::mutex;
 
 TEST(HeapBasedPoolAllocator, Concurrency)
 {
+#ifdef __linux__
     std::cout << ">>> HEAP BEFORE:" << std::endl;
     malloc_stats();
 
+#endif
     uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize, RaiiSynchronizer> al(1000);
 
     ASSERT_EQ(1000, al.getBlockCapacity());
@@ -167,13 +177,17 @@ TEST(HeapBasedPoolAllocator, Concurrency)
     std::cout << "Allocated: " << al.getNumAllocatedBlocks() << std::endl;
     std::cout << "Reserved:  " << al.getNumReservedBlocks() << std::endl;
 
+#ifdef __linux__
     std::cout << ">>> HEAP BEFORE SHRINK:" << std::endl;
     malloc_stats();
 
+#endif
     al.shrink();
 
+#ifdef __linux__
     std::cout << ">>> HEAP AFTER SHRINK:" << std::endl;
     malloc_stats();
+#endif
 }
 
 #endif


### PR DESCRIPTION
Problem:
It's really hard to get Libuavcan tests building on a mac or other platform if googletest isn't installed.

Solution:
add "if linux" guards to problem areas. Also include googletest as recommended in the googletest project's README.

Testing:
Successfully built on OSX sierra using gcc6