### PR TITLE
Support upstream NuttX IRQ API changes

### DIFF
--- a/libuavcan_drivers/stm32/driver/src/internal.hpp
+++ b/libuavcan_drivers/stm32/driver/src/internal.hpp
@@ -43,7 +43,7 @@
 # define UAVCAN_STM32_IRQ_PROLOGUE()    CH_IRQ_PROLOGUE()
 # define UAVCAN_STM32_IRQ_EPILOGUE()    CH_IRQ_EPILOGUE()
 #elif UAVCAN_STM32_NUTTX
-# define UAVCAN_STM32_IRQ_HANDLER(id)  int id(int irq, FAR void* context)
+# define UAVCAN_STM32_IRQ_HANDLER(id)  int id(int irq, FAR void* context, FAR void *arg)
 # define UAVCAN_STM32_IRQ_PROLOGUE()
 # define UAVCAN_STM32_IRQ_EPILOGUE()    return 0;
 #else

--- a/libuavcan_drivers/stm32/driver/src/uc_stm32_can.cpp
+++ b/libuavcan_drivers/stm32/driver/src/uc_stm32_can.cpp
@@ -50,9 +50,9 @@
 # endif
 extern "C"
 {
-static int can1_irq(const int irq, void*);
+static int can1_irq(const int irq, void*, void*);
 #if UAVCAN_STM32_NUM_IFACES > 1
-static int can2_irq(const int irq, void*);
+static int can2_irq(const int irq, void*, void*);
 #endif
 }
 #endif
@@ -1010,7 +1010,7 @@ void CanDriver::initOnce()
 #if UAVCAN_STM32_NUTTX
 # define IRQ_ATTACH(irq, handler)                          \
     {                                                      \
-        const int res = irq_attach(irq, handler);          \
+        const int res = irq_attach(irq, handler, NULL);    \
         (void)res;                                         \
         assert(res >= 0);                                  \
         up_enable_irq(irq);                                \
@@ -1119,7 +1119,7 @@ extern "C"
 
 #if UAVCAN_STM32_NUTTX
 
-static int can1_irq(const int irq, void*)
+static int can1_irq(const int irq, void*, void*)
 {
     if (irq == STM32_IRQ_CAN1TX)
     {
@@ -1142,7 +1142,7 @@ static int can1_irq(const int irq, void*)
 
 # if UAVCAN_STM32_NUM_IFACES > 1
 
-static int can2_irq(const int irq, void*)
+static int can2_irq(const int irq, void*, void*)
 {
     if (irq == STM32_IRQ_CAN2TX)
     {

--- a/libuavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
+++ b/libuavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
@@ -151,7 +151,7 @@ void init()
 # if UAVCAN_STM32_NUTTX
 
     // Attach IRQ
-    irq_attach(TIMX_IRQn, &TIMX_IRQHandler);
+    irq_attach(TIMX_IRQn, &TIMX_IRQHandler, NULL);
 
     // Power-on and reset
     modifyreg32(STM32_RCC_APB1ENR, 0, TIMX_RCC_ENR_MASK);


### PR DESCRIPTION
@pavel-kirienko @dagar - I rebased this on current master and tested on FMUv5. 

@pavel-kirienko unless you see any need to carry support for NuttX < 7.22 this shuuld come into master.