### PR TITLE
Issue #100 remove auto_ptr and c++03 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_install:
     - ./bootstrap.sh
 before_script: "mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCONTINUOUS_INTEGRATION_BUILD=1"
 script:
-    - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "native" ]; then make ; fi
-    - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "lpc11c24" ]; then cd "$TRAVIS_BUILD_DIR/libuavcan_drivers/lpc11c24/test_olimex_lpc_p11c24" && make all ; fi
+    - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "native" ]; then make && make ARGS=-VV test; fi
+    - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "lpc11c24" ]; then cd "$TRAVIS_BUILD_DIR/libuavcan_drivers/lpc11c24/test_olimex_lpc_p11c24" && make all; fi
     - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "stm32" ]; then echo "TODO STM32 test environment is not configured"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(opts
     "CMAKE_BUILD_TYPE:STRING:RelWithDebInfo:Debug Release RelWithDebInfo MinSizeRel:Build type."
     "CMAKE_CXX_FLAGS:STRING:::C++ flags."
     "CMAKE_C_FLAGS:STRING:::C flags."
-    "UAVCAN_USE_CPP03:BOOL:OFF::Use C++03 standard."
     "UAVCAN_PLATFORM:STRING:generic:generic linux stm32:Platform."
     "CONTINUOUS_INTEGRATION_BUILD:BOOL:OFF::Disable error redirection and timing tests"
     "UAVCAN_CMAKE_VERBOSE:BOOL:OFF::Verbose CMake configure output"
@@ -99,6 +98,8 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
                             EXCLUDE_FROM_ALL)
 
             set(GTEST_FOUND ON)
+            set(BUILD_TESTING ON)
+            enable_testing()
         endif()
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ make -j8
 ## Library development
 
 Despite the fact that the library itself can be used on virtually any platform that has a standard-compliant
-C++03 or C++11 compiler, the library development process assumes that the host OS is Linux.
+C++11 compiler, the library development process assumes that the host OS is Linux.
 
 Prerequisites:
 
@@ -102,7 +102,8 @@ Building the debug version and running the unit tests:
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug
-make
+make -j8
+make ARGS=-VV test
 ```
 
 Test outputs can be found in the build directory under `libuavcan`.

--- a/libuavcan/CMakeLists.txt
+++ b/libuavcan/CMakeLists.txt
@@ -56,13 +56,8 @@ include_directories(${DSDLC_OUTPUT})
 #
 if (COMPILER_IS_GCC_COMPATIBLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wundef")
-    if (UAVCAN_USE_CPP03)
-        message(STATUS "Using C++03")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03 -Wno-variadic-macros -Wno-long-long")
-    else ()
-        message(STATUS "Using C++11 (pass UAVCAN_USE_CPP03=1 to override)")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif ()
+    message(STATUS "Using C++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif ()
 
 if (DEBUG_BUILD)
@@ -108,13 +103,13 @@ function(add_libuavcan_test name library flags) # Adds GTest executable and crea
     # If failing tests need to be investigated with debugger, use 'make --ignore-errors'
     if (CONTINUOUS_INTEGRATION_BUILD)
         # Don't redirect test output, and don't run tests suffixed with "RealTime"
-        add_custom_command(TARGET ${name} POST_BUILD
-                           COMMAND ./${name} --gtest_filter=-*RealTime
-                           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        add_test(NAME ${name}
+                 COMMAND ${name} --gtest_filter=-*RealTime
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else ()
-        add_custom_command(TARGET ${name} POST_BUILD
-                           COMMAND ./${name} 1>"${name}.log" 2>&1
-                           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        add_test(NAME ${name}
+             COMMAND ${name} 1>"${name}.log" 2>&1
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 endfunction()
 
@@ -129,8 +124,6 @@ if (DEBUG_BUILD)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wzero-as-null-pointer-constant -Wnon-virtual-dtor")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wsign-promo -Wold-style-cast")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
-        #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++ -Wno-error=effc++")  # Produces heaps of useless warnings
-        set(cpp03_flags "-std=c++03 -Wno-variadic-macros -Wno-long-long -Wno-zero-as-null-pointer-constant")
         set(optim_flags "-O3 -DNDEBUG -g0")
     else ()
         message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
@@ -138,9 +131,6 @@ if (DEBUG_BUILD)
     endif ()
 
     # Additional flavours of the library
-    add_library(uavcan_cpp03 STATIC ${LIBUAVCAN_CXX_FILES})
-    set_target_properties(uavcan_cpp03 PROPERTIES COMPILE_FLAGS ${cpp03_flags})
-    add_dependencies(uavcan_cpp03 libuavcan_dsdlc)
 
     add_library(uavcan_optim STATIC ${LIBUAVCAN_CXX_FILES})
     set_target_properties(uavcan_optim PROPERTIES COMPILE_FLAGS ${optim_flags})
@@ -149,7 +139,6 @@ if (DEBUG_BUILD)
     if (GTEST_FOUND)
         message(STATUS "GTest found, tests will be built and run.")
         add_libuavcan_test(libuavcan_test       uavcan       "")                 # Default
-        add_libuavcan_test(libuavcan_test_cpp03 uavcan_cpp03 "${cpp03_flags}")   # C++03
         add_libuavcan_test(libuavcan_test_optim uavcan_optim "${optim_flags}")   # Max optimization
     else (GTEST_FOUND)
         message(STATUS "GTest was not found, tests will not be built")

--- a/libuavcan/test/node/test_node.hpp
+++ b/libuavcan/test/node/test_node.hpp
@@ -5,8 +5,6 @@
 #pragma once
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -217,7 +215,7 @@ struct TestNetwork
         { }
     };
 
-    std::auto_ptr<NodeEnvironment> nodes[NumNodes];
+    std::unique_ptr<NodeEnvironment> nodes[NumNodes];
 
     TestNetwork(uavcan::uint8_t first_node_id = 1)
     {

--- a/libuavcan/test/protocol/data_type_info_provider.cpp
+++ b/libuavcan/test/protocol/data_type_info_provider.cpp
@@ -18,7 +18,7 @@ using uavcan::DefaultDataTypeRegistrator;
 using uavcan::MonotonicDuration;
 
 template <typename DataType>
-static bool validateDataTypeInfoResponse(const std::auto_ptr<ServiceCallResultCollector<GetDataTypeInfo>::Result>& resp,
+static bool validateDataTypeInfoResponse(const std::unique_ptr<ServiceCallResultCollector<GetDataTypeInfo>::Result>& resp,
                                          unsigned flags)
 {
     if (!resp.get())

--- a/libuavcan/test/protocol/dynamic_node_id_server/distributed/server.cpp
+++ b/libuavcan/test/protocol/dynamic_node_id_server/distributed/server.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -57,8 +55,8 @@ TEST(dynamic_node_id_server_RaftCore, Basic)
 
     InterlinkedTestNodesWithSysClock nodes;
 
-    std::auto_ptr<RaftCore> raft_a(new RaftCore(nodes.a, storage_a, tracer_a, commit_handler_a));
-    std::auto_ptr<RaftCore> raft_b(new RaftCore(nodes.b, storage_b, tracer_b, commit_handler_b));
+    std::unique_ptr<RaftCore> raft_a(new RaftCore(nodes.a, storage_a, tracer_a, commit_handler_a));
+    std::unique_ptr<RaftCore> raft_b(new RaftCore(nodes.b, storage_b, tracer_b, commit_handler_b));
 
     /*
      * Initialization

--- a/libuavcan/test/protocol/dynamic_node_id_server/node_discoverer.cpp
+++ b/libuavcan/test/protocol/dynamic_node_id_server/node_discoverer.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 

--- a/libuavcan/test/protocol/firmware_update_trigger.cpp
+++ b/libuavcan/test/protocol/firmware_update_trigger.cpp
@@ -107,7 +107,7 @@ TEST(FirmwareUpdateTrigger, Basic)
     uavcan::FirmwareUpdateTrigger trigger(nodes.a, checker);
     std::cout << "sizeof(uavcan::FirmwareUpdateTrigger): " << sizeof(uavcan::FirmwareUpdateTrigger) << std::endl;
 
-    std::auto_ptr<uavcan::NodeStatusProvider> provider(new uavcan::NodeStatusProvider(nodes.b));    // Other node
+    std::unique_ptr<uavcan::NodeStatusProvider> provider(new uavcan::NodeStatusProvider(nodes.b));    // Other node
 
     /*
      * Initializing
@@ -235,10 +235,10 @@ TEST(FirmwareUpdateTrigger, MultiNode)
     uavcan::FirmwareUpdateTrigger trigger(nodes[0], checker);
 
     // The client nodes
-    std::auto_ptr<uavcan::NodeStatusProvider> provider_a(new uavcan::NodeStatusProvider(nodes[1]));
-    std::auto_ptr<uavcan::NodeStatusProvider> provider_b(new uavcan::NodeStatusProvider(nodes[2]));
-    std::auto_ptr<uavcan::NodeStatusProvider> provider_c(new uavcan::NodeStatusProvider(nodes[3]));
-    std::auto_ptr<uavcan::NodeStatusProvider> provider_d(new uavcan::NodeStatusProvider(nodes[4]));
+    std::unique_ptr<uavcan::NodeStatusProvider> provider_a(new uavcan::NodeStatusProvider(nodes[1]));
+    std::unique_ptr<uavcan::NodeStatusProvider> provider_b(new uavcan::NodeStatusProvider(nodes[2]));
+    std::unique_ptr<uavcan::NodeStatusProvider> provider_c(new uavcan::NodeStatusProvider(nodes[3]));
+    std::unique_ptr<uavcan::NodeStatusProvider> provider_d(new uavcan::NodeStatusProvider(nodes[4]));
 
     uavcan::protocol::HardwareVersion hwver;
 

--- a/libuavcan/test/protocol/helpers.hpp
+++ b/libuavcan/test/protocol/helpers.hpp
@@ -20,7 +20,7 @@ class SubscriptionCollector : uavcan::Noncopyable
     }
 
 public:
-    std::auto_ptr<DataType> msg;
+    std::unique_ptr<DataType> msg;
 
     typedef uavcan::MethodBinder<SubscriptionCollector*,
                                  void (SubscriptionCollector::*)(const DataType&)> Binder;
@@ -85,7 +85,7 @@ private:
     }
 
 public:
-    std::auto_ptr<Result> result;
+    std::unique_ptr<Result> result;
 
     typedef uavcan::MethodBinder<ServiceCallResultCollector*,
                                  void (ServiceCallResultCollector::*)(const uavcan::ServiceCallResult<DataType>&)>

--- a/libuavcan/test/protocol/node_info_retriever.cpp
+++ b/libuavcan/test/protocol/node_info_retriever.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -27,7 +25,7 @@ static void publishNodeStatus(PairableCanDriver& can, uavcan::NodeID node_id,
 
 struct NodeInfoListener : public uavcan::INodeInfoListener
 {
-    std::auto_ptr<uavcan::protocol::GetNodeInfo::Response> last_node_info;
+    std::unique_ptr<uavcan::protocol::GetNodeInfo::Response> last_node_info;
     uavcan::NodeID last_node_id;
     unsigned status_message_cnt;
     unsigned status_change_cnt;
@@ -82,7 +80,7 @@ TEST(NodeInfoRetriever, Basic)
     std::cout << "sizeof(uavcan::ServiceClient<uavcan::protocol::GetNodeInfo>): "
         << sizeof(uavcan::ServiceClient<uavcan::protocol::GetNodeInfo>) << std::endl;
 
-    std::auto_ptr<uavcan::NodeStatusProvider> provider(new uavcan::NodeStatusProvider(nodes.b));
+    std::unique_ptr<uavcan::NodeStatusProvider> provider(new uavcan::NodeStatusProvider(nodes.b));
 
     NodeInfoListener listener;
 

--- a/libuavcan/test/transport/dispatcher.cpp
+++ b/libuavcan/test/transport/dispatcher.cpp
@@ -84,7 +84,7 @@ TEST(Dispatcher, Reception)
         makeDataType(uavcan::DataTypeKindService, 1)
     };
 
-    typedef std::auto_ptr<TestListener> TestListenerPtr;
+    typedef std::unique_ptr<TestListener> TestListenerPtr;
     static const int MaxBufSize = 512;
     static const int NumSubscribers = 6;
     TestListenerPtr subscribers[NumSubscribers] =

--- a/libuavcan/test/transport/transfer_buffer.cpp
+++ b/libuavcan/test/transport/transfer_buffer.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -238,7 +236,7 @@ TEST(TransferBufferManager, Basic)
     static const int POOL_BLOCKS = 100;
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
-    std::auto_ptr<TransferBufferManager> mgr(new TransferBufferManager(MGR_MAX_BUFFER_SIZE, pool));
+    std::unique_ptr<TransferBufferManager> mgr(new TransferBufferManager(MGR_MAX_BUFFER_SIZE, pool));
 
     // Empty
     ASSERT_FALSE(mgr->access(TransferBufferManagerKey(0, uavcan::TransferTypeMessageBroadcast)));

--- a/libuavcan/test/util/map.cpp
+++ b/libuavcan/test/util/map.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -59,7 +57,7 @@ TEST(Map, Basic)
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
     typedef Map<std::string, std::string> MapType;
-    std::auto_ptr<MapType> map(new MapType(pool));
+    std::unique_ptr<MapType> map(new MapType(pool));
 
     // Empty
     ASSERT_FALSE(map->access("hi"));
@@ -198,7 +196,7 @@ TEST(Map, PrimitiveKey)
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
     typedef Map<short, short> MapType;
-    std::auto_ptr<MapType> map(new MapType(pool));
+    std::unique_ptr<MapType> map(new MapType(pool));
 
     // Empty
     ASSERT_FALSE(map->access(1));

--- a/libuavcan/test/util/multiset.cpp
+++ b/libuavcan/test/util/multiset.cpp
@@ -3,8 +3,6 @@
  */
 
 #if __GNUC__
-// We need auto_ptr for compatibility reasons
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
 
@@ -78,7 +76,7 @@ TEST(Multiset, Basic)
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
     typedef Multiset<std::string> MultisetType;
-    std::auto_ptr<MultisetType> mset(new MultisetType(pool));
+    std::unique_ptr<MultisetType> mset(new MultisetType(pool));
 
     typedef SummationOperator<std::string> StringConcatenationOperator;
 
@@ -199,7 +197,7 @@ TEST(Multiset, PrimitiveKey)
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
     typedef Multiset<int> MultisetType;
-    std::auto_ptr<MultisetType> mset(new MultisetType(pool));
+    std::unique_ptr<MultisetType> mset(new MultisetType(pool));
 
     // Empty
     mset->removeFirst(8);
@@ -239,7 +237,7 @@ TEST(Multiset, NoncopyableWithCounter)
     uavcan::PoolAllocator<uavcan::MemPoolBlockSize * POOL_BLOCKS, uavcan::MemPoolBlockSize> pool;
 
     typedef Multiset<NoncopyableWithCounter> MultisetType;
-    std::auto_ptr<MultisetType> mset(new MultisetType(pool));
+    std::unique_ptr<MultisetType> mset(new MultisetType(pool));
 
     ASSERT_EQ(0, NoncopyableWithCounter::num_objects);
     ASSERT_EQ(0,    mset->emplace()->value);


### PR DESCRIPTION
Problem:
auto_ptr is deprecated.

Solution:
use unique_ptr which is only available in c++11 and newer.
Also fix how unit tests are run as part of the build to keep them from being
deleted when they fail.

Testing:
Unit tests on linux run.