### PR TITLE
Issue #141 Add Vagrantfile to automate dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__
 # vsstudio code
 .vscode
 
+# vagrant
+.vagrant
+
 # libuavcan DSDL compiler default output directory
 dsdlc_generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,7 @@ addons:
     build_command: "make --ignore-errors"
     branch_pattern: coverity_scan
 before_install:
-    - git submodule update --init --recursive
-    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    - sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded -y
-    - sudo apt-get update -qq
-    - if [ "$CXX" = "g++" ]; then sudo apt-get install --force-yes -qq g++-4.8; fi
-    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-    - sudo apt-get install --force-yes gcc-arm-none-eabi
+    - ./bootstrap.sh
 before_script: "mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCONTINUOUS_INTEGRATION_BUILD=1"
 script:
     - if [ "${COVERITY_SCAN_BRANCH}" != 1 ] && [ "${TARGET}" == "native" ]; then make ; fi

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           98a0d007d7092b72eea0e501bb9ad17908a1a036
+  GIT_TAG           ba96d0b1161f540656efdaed035b3c062b60e006
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ C++03 or C++11 compiler, the library development process assumes that the host O
 
 Prerequisites:
 
-* Google test library for C++ - gtest (see [how to install on Debian/Ubuntu](http://stackoverflow.com/questions/13513905/how-to-properly-setup-googletest-on-linux))
-* C++03 *and* C++11 capable compiler with GCC-like interface (e.g. GCC, Clang)
+* Google test library for C++ - gtest (dowloaded as part of the build from [github](https://github.com/google/googletest))
+* C++11 capable compiler with GCC-like interface (e.g. GCC, Clang)
 * CMake 2.8+
 * Optional: static analysis tool for C++ - cppcheck (on Debian/Ubuntu use package `cppcheck`)
 
@@ -106,10 +106,36 @@ make
 ```
 
 Test outputs can be found in the build directory under `libuavcan`.
-Note that unit tests must be executed in real time, otherwise they may produce false warnings;
+
+> Note that unit tests suffixed with "_RealTime" must be executed in real time, otherwise they may produce false warnings;
 this implies that they will likely fail if ran on a virtual machine or on a highly loaded system.
 
 Contributors, please follow the [Zubax C++ Coding Conventions](https://kb.zubax.com/x/84Ah).
+
+### Vagrant
+Vagrant can be used to setup a compatible Ubuntu virtual image. Follow the instructions on [Vagrantup](https://www.vagrantup.com/) to install virtualbox and vagrant then do:
+
+```bash
+vagrant up
+vagrant ssh
+mkdir build
+cd build
+mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DCONTINUOUS_INTEGRATION_BUILD=1
+```
+
+> Note that -DCONTINUOUS_INTEGRATION_BUILD=1 is required for this build as the realtime unit tests will not work on a virt.
+
+You can build using commands like:
+
+```bash
+vagrant ssh -c "cd /vagrant/build && make -j4 && make test"
+```
+
+or to run a single test:
+
+```bash
+vagrant ssh -c "cd /vagrant/build && make libuavcan_test && ./libuavcan/libuavcan_test --gtest_filter=Node.Basic"
+```
 
 ### Developing with Eclipse
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  
+  config.vm.box = "ubuntu/trusty64"
+  
+  # use shell and other provisioners as usual
+  config.vm.provision :shell, path: "bootstrap.sh"
+  
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+    v.cpus = 4
+  end
+  config.vm.provision "shell" do |s|
+    s.inline = <<-SCRIPT
+      # Change directory automatically on ssh login
+      echo "cd    /vagrant" >> /home/vagrant/.bashrc
+    SCRIPT
+  end
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# +----------------------------------------------------------+
+# | BASH : Modifying Shell Behaviour
+# |    (https://www.gnu.org/software/bash/manual)
+# +----------------------------------------------------------+
+# Treat unset variables and parameters other than the special 
+# parameters ‘@’ or ‘*’ as an error when performing parameter 
+# expansion. An error message will be written to the standard 
+# error, and a non-interactive shell will exit.
+set -o nounset
+
+# Exit immediately if a pipeline returns a non-zero status.
+set -o errexit
+
+# If set, the return value of a pipeline is the value of the 
+# last (rightmost) command to exit with a non-zero status, or 
+# zero if all commands in the pipeline exit successfully.
+set -o pipefail
+
+# +----------------------------------------------------------+
+
+sudo apt-get update
+sudo apt-get -y install software-properties-common
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
+sudo apt-get update
+sudo apt-get -y install cmake
+sudo apt-get -y install python3
+sudo apt-get -y install git
+sudo apt-get -y install g++-5;
+sudo apt-get -y install gcc-arm-embedded
+
+# Export to tell cmake which native compilers to use.
+export CXX="g++-5" CC="gcc-5";

--- a/libuavcan/include/uavcan/util/templates.hpp
+++ b/libuavcan/include/uavcan/util/templates.hpp
@@ -202,7 +202,7 @@ struct EnumMin
 /**
  * Selects larger value
  */
-template <long A, long B>
+template <unsigned long A, unsigned long B>
 struct EnumMax
 {
     enum { Result = (A > B) ? A : B };


### PR DESCRIPTION
Problem:
There is no automated way to setup a build environment.

Solution:
Use Vagrant to pull an Ubuntu image and install the same
prerequisites used on Travis.

Testing:
Full build on my macintosh.

#141 