### PR TITLE
Use C++11 std::enable_if instead of our own

### DIFF
--- a/libuavcan/include/uavcan/marshal/array.hpp
+++ b/libuavcan/include/uavcan/marshal/array.hpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cmath>
+#include <type_traits>
 #include <uavcan/error.hpp>
 #include <uavcan/util/bitset.hpp>
 #include <uavcan/util/templates.hpp>
@@ -293,7 +294,7 @@ private:
     BufferType data_;
 
     template <typename U>
-    typename EnableIf<sizeof(U(0) >= U())>::Type initialize(int)
+    typename std::enable_if<sizeof(U(0) >= U())>::type initialize(int)
     {
         if (ArrayMode != ArrayModeDynamic)
         {
@@ -761,8 +762,8 @@ public:
      * Members must be comparable via operator ==.
      */
     template <typename R>
-    typename EnableIf<sizeof((reinterpret_cast<const R*>(0))->size()) &&
-                      sizeof((*(reinterpret_cast<const R*>(0)))[0]), bool>::Type
+    typename std::enable_if<sizeof((reinterpret_cast<const R*>(0))->size()) &&
+                            sizeof((*(reinterpret_cast<const R*>(0)))[0]), bool>::type
     operator==(const R& rhs) const
     {
         if (size() != rhs.size())
@@ -787,8 +788,8 @@ public:
      * Any container with size() and [] is acceptable.
      */
     template <typename R>
-    typename EnableIf<sizeof((reinterpret_cast<const R*>(0))->size()) &&
-                      sizeof((*(reinterpret_cast<const R*>(0)))[0]), bool>::Type
+    typename std::enable_if<sizeof((reinterpret_cast<const R*>(0))->size()) &&
+                            sizeof((*(reinterpret_cast<const R*>(0)))[0]), bool>::type
     isClose(const R& rhs) const
     {
         if (size() != rhs.size())
@@ -1003,8 +1004,8 @@ public:
      * Note that matrix packing code uses @ref areClose() for comparison.
      */
     template <typename R>
-    typename EnableIf<sizeof((reinterpret_cast<const R*>(0))->begin()) &&
-                      sizeof((reinterpret_cast<const R*>(0))->size())>::Type
+    typename std::enable_if<sizeof((reinterpret_cast<const R*>(0))->begin()) &&
+                            sizeof((reinterpret_cast<const R*>(0))->size())>::type
     packSquareMatrix(const R& src_row_major)
     {
         if (src_row_major.size() == MaxSize)
@@ -1060,8 +1061,8 @@ public:
      * Please refer to the specification to learn more about matrix packing.
      */
     template <typename R>
-    typename EnableIf<sizeof((reinterpret_cast<const R*>(0))->begin()) &&
-                      sizeof((reinterpret_cast<const R*>(0))->size())>::Type
+    typename std::enable_if<sizeof((reinterpret_cast<const R*>(0))->begin()) &&
+                            sizeof((reinterpret_cast<const R*>(0))->size())>::type
     unpackSquareMatrix(R& dst_row_major) const
     {
         if (dst_row_major.size() == MaxSize)
@@ -1097,7 +1098,7 @@ public:
  */
 template <typename R, typename T, ArrayMode ArrayMode, unsigned MaxSize>
 UAVCAN_EXPORT
-inline typename EnableIf<!IsSameType<R, Array<T, ArrayMode, MaxSize> >::Result, bool>::Type
+inline typename std::enable_if<!IsSameType<R, Array<T, ArrayMode, MaxSize> >::Result, bool>::type
 operator==(const R& rhs, const Array<T, ArrayMode, MaxSize>& lhs)
 {
     return lhs.operator==(rhs);
@@ -1105,7 +1106,7 @@ operator==(const R& rhs, const Array<T, ArrayMode, MaxSize>& lhs)
 
 template <typename R, typename T, ArrayMode ArrayMode, unsigned MaxSize>
 UAVCAN_EXPORT
-inline typename EnableIf<!IsSameType<R, Array<T, ArrayMode, MaxSize> >::Result, bool>::Type
+inline typename std::enable_if<!IsSameType<R, Array<T, ArrayMode, MaxSize> >::Result, bool>::type
 operator!=(const R& rhs, const Array<T, ArrayMode, MaxSize>& lhs)
 {
     return lhs.operator!=(rhs);

--- a/libuavcan/include/uavcan/marshal/scalar_codec.hpp
+++ b/libuavcan/include/uavcan/marshal/scalar_codec.hpp
@@ -6,6 +6,7 @@
 #define UAVCAN_MARSHAL_SCALAR_CODEC_HPP_INCLUDED
 
 #include <cassert>
+#include <type_traits>
 #include <uavcan/std.hpp>
 #include <uavcan/build_config.hpp>
 #include <uavcan/util/templates.hpp>
@@ -24,7 +25,7 @@ class UAVCAN_EXPORT ScalarCodec
     static void swapByteOrder(uint8_t* bytes, unsigned len);
 
     template <unsigned BitLen, unsigned Size>
-    static typename EnableIf<(BitLen > 8)>::Type
+    static typename std::enable_if<(BitLen > 8)>::type
     convertByteOrder(uint8_t (&bytes)[Size])
     {
 #if defined(BYTE_ORDER) && defined(BIG_ENDIAN)
@@ -46,11 +47,11 @@ class UAVCAN_EXPORT ScalarCodec
     }
 
     template <unsigned BitLen, unsigned Size>
-    static typename EnableIf<(BitLen <= 8)>::Type
+    static typename std::enable_if<(BitLen <= 8)>::type
     convertByteOrder(uint8_t (&)[Size]) { }
 
     template <unsigned BitLen, typename T>
-    static typename EnableIf<static_cast<bool>(NumericTraits<T>::IsSigned) && ((sizeof(T) * 8) > BitLen)>::Type
+    static typename std::enable_if<static_cast<bool>(NumericTraits<T>::IsSigned) && ((sizeof(T) * 8) > BitLen)>::type
     fixTwosComplement(T& value)
     {
         StaticAssert<NumericTraits<T>::IsInteger>::check(); // Not applicable to floating point types
@@ -61,18 +62,18 @@ class UAVCAN_EXPORT ScalarCodec
     }
 
     template <unsigned BitLen, typename T>
-    static typename EnableIf<!static_cast<bool>(NumericTraits<T>::IsSigned) || ((sizeof(T) * 8) == BitLen)>::Type
+    static typename std::enable_if<!static_cast<bool>(NumericTraits<T>::IsSigned) || ((sizeof(T) * 8) == BitLen)>::type
     fixTwosComplement(T&) { }
 
     template <unsigned BitLen, typename T>
-    static typename EnableIf<((sizeof(T) * 8) > BitLen)>::Type
+    static typename std::enable_if<((sizeof(T) * 8) > BitLen)>::type
     clearExtraBits(T& value)
     {
         value &= (T(1) << BitLen) - 1;  // Signedness doesn't matter
     }
 
     template <unsigned BitLen, typename T>
-    static typename EnableIf<((sizeof(T) * 8) == BitLen)>::Type
+    static typename std::enable_if<((sizeof(T) * 8) == BitLen)>::type
     clearExtraBits(T&) { }
 
     template <unsigned BitLen, typename T>

--- a/libuavcan/include/uavcan/marshal/type_util.hpp
+++ b/libuavcan/include/uavcan/marshal/type_util.hpp
@@ -5,6 +5,7 @@
 #ifndef UAVCAN_MARSHAL_TYPE_UTIL_HPP_INCLUDED
 #define UAVCAN_MARSHAL_TYPE_UTIL_HPP_INCLUDED
 
+#include <type_traits>
 #include <uavcan/build_config.hpp>
 #include <uavcan/util/templates.hpp>
 #include <uavcan/util/comparison.hpp>
@@ -68,7 +69,7 @@ class IsPrimitiveType
     struct No { Yes dummy[8]; };
 
     template <typename U>
-    static typename EnableIf<U::IsPrimitive, Yes>::Type test(int);
+    static typename std::enable_if<U::IsPrimitive, Yes>::type test(int);
 
     template <typename>
     static No test(...);

--- a/libuavcan/include/uavcan/util/templates.hpp
+++ b/libuavcan/include/uavcan/util/templates.hpp
@@ -53,18 +53,6 @@ protected:
 };
 
 /**
- * Compile time conditions
- */
-template <bool B, typename T = void>
-struct UAVCAN_EXPORT EnableIf { };
-
-template <typename T>
-struct UAVCAN_EXPORT EnableIf<true, T>
-{
-    typedef T Type;
-};
-
-/**
  * Lightweight type categorization.
  */
 template <typename T, typename R = void>


### PR DESCRIPTION
We recently decided to remove support for C++03, which means we can now
use standard library constructs.

Fixes #149  (Replace all use of uavcan::EnableIf with std::enable_if).