### PR TITLE
use PRIu32 instead of %u to for better wformat compliance

### DIFF
--- a/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
+++ b/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
@@ -139,9 +139,9 @@ int CanAcceptanceFilterConfigurator::applyConfiguration(void)
     for (uint16_t i = 0; i < multiset_configs_.getSize(); i++)
     {
         UAVCAN_TRACE("CanAcceptanceFilterConfigurator::applyConfiguration()", "cfg.ID [%u] = %u", i,
-                     multiset_configs_.getByIndex(i)->id);
+                     static_cast<unsigned>(multiset_configs_.getByIndex(i)->id));
         UAVCAN_TRACE("CanAcceptanceFilterConfigurator::applyConfiguration()", "cfg.MK [%u] = %u", i,
-                     multiset_configs_.getByIndex(i)->mask);
+                     static_cast<unsigned>(multiset_configs_.getByIndex(i)->mask));
     }
 #endif
 


### PR DESCRIPTION
On our platform (GCC 4.9.4 for PowerPC), the following fails to compile in debug mode with the extra error checking turned on because for us std::uint32_t is an unsigned long rather than unsigned int.

<redacted>/libuavcan/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp: In member function 'int uavcan::CanAcceptanceFilterConfigurator::applyConfiguration()':
<redacted>/libuavcan/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp:142:57: error: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uavcan::uint32_t {aka long unsigned int}' [-Werror=format=]
                      multiset_configs_.getByIndex(i)->id);

Instead of using %u, using %PRIu32 from cinttypes allows it to compile.