### PR TITLE
In which we argue about build flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,77 @@
+#
+# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+
+cmake_minimum_required(VERSION 3.5.1)
+
+project(libuavcan CXX)
+
+#
+# Framework : Googletest
+#
+# (Taken from googletest/README.md documentation)
+# GTest executables
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+    message(WARNING "CMake step for googletest failed: ${result}")
+else()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+    if(result)
+        message(WARNING "Build step for googletest failed: ${result}")
+    else()
+
+        # Prevent overriding the parent project's compiler/linker
+        # settings on Windows
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+        # Add googletest directly to our build. This defines
+        # the gtest and gtest_main targets.
+        add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                        ${CMAKE_BINARY_DIR}/googletest-build
+                        EXCLUDE_FROM_ALL)
+
+        set(GTEST_FOUND ON)
+        set(BUILD_TESTING ON)
+        enable_testing()
+    endif()
+endif()
+
+#
+# Set flags
+#
+include_directories(
+    ./libuavcan/include/
+)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-exceptions -fno-threadsafe-statics")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og -DNDEBUG -ggdb -fno-strict-aliasing")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic -Wfloat-equal -Wconversion -Wabi")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-parameter -Wunused-variable -Wunused-value")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-align -Wmissing-declarations -Wno-missing-field-initializers ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Wswitch-enum -Wtype-limits -Wno-error=array-bounds")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wzero-as-null-pointer-constant -Wnon-virtual-dtor")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wsign-promo -Wold-style-cast")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion")
+
+#
+# Test : All Unit Tests
+#
+file(GLOB_RECURSE TEST_CXX_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "test/*.cpp")
+add_executable(libuavcan_test_native ${TEST_CXX_FILES})
+
+target_link_libraries(libuavcan_test_native gmock_main)
+
+# Tests run automatically upon successful build
+# If failing tests need to be investigated with debugger, use 'make --ignore-errors'
+add_test(NAME libuavcan_test_native
+         COMMAND libuavcan_test_native
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           9318a18ccf8f975fbabbfc1c0f4d816cf16b1803
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   
   # use shell and other provisioners as usual
   config.vm.provision :shell, path: "build_steps/provision.sh"

--- a/build_steps/provision.sh
+++ b/build_steps/provision.sh
@@ -22,13 +22,11 @@ set -o pipefail
 
 sudo apt-get update
 sudo apt-get -y install software-properties-common
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
 sudo apt-get update
 sudo apt-get -y install python-pip
 sudo apt-get -y install cmake
 sudo apt-get -y install git
-sudo apt-get -y install g++-7;
 sudo apt-get -y install gcc-arm-embedded
 
 pip install --user pyyaml

--- a/libuavcan/include/uavcan/build_config.hpp
+++ b/libuavcan/include/uavcan/build_config.hpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ */
+
+#ifndef UAVCAN_BUILD_CONFIG_HPP_INCLUDED
+#define UAVCAN_BUILD_CONFIG_HPP_INCLUDED
+
+/**
+ * UAVCAN version definition
+ */
+#define UAVCAN_VERSION_MAJOR    2
+#define UAVCAN_VERSION_MINOR    0
+
+
+#endif // UAVCAN_BUILD_CONFIG_HPP_INCLUDED

--- a/libuavcan/include/uavcan/uavcan.hpp
+++ b/libuavcan/include/uavcan/uavcan.hpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This header should be included by the user application.
+ */
+
+#ifndef UAVCAN_UAVCAN_HPP_INCLUDED
+#define UAVCAN_UAVCAN_HPP_INCLUDED
+
+#include <uavcan/build_config.hpp>
+
+#endif // UAVCAN_UAVCAN_HPP_INCLUDED

--- a/test/native/test_build_config.cpp
+++ b/test/native/test_build_config.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Unit tests of the build_config.hpp header.
+ */
+
+#include "uavcan/uavcan.hpp"
+#include "gtest/gtest.h"
+
+TEST(BuildConfigTest, Version) {
+    ASSERT_EQ(2, UAVCAN_VERSION_MAJOR) << "These tests are designed for version 2 of libuavcan" << std::endl;
+}


### PR DESCRIPTION
Time to have this argument.
Also: decided to continue with #ifdef include guards unless you want to
have the pragma argument too?

Other decisions in here:
- bionic as a reference build environment for CI (because xenial is EOL in two years)
- cmake 3.5.1 because that's the default in bionic and it's not all that new either.
