### PR TITLE
Removed assert for big endian machines.

### DIFF
--- a/libuavcan/include/uavcan/marshal/scalar_codec.hpp
+++ b/libuavcan/include/uavcan/marshal/scalar_codec.hpp
@@ -34,11 +34,6 @@ class UAVCAN_EXPORT ScalarCodec
         u.l = 1;
         const bool big_endian = u.c[sizeof(long int) - 1] == 1;
 #endif
-        /*
-         * I didn't have any big endian machine nearby, so big endian support wasn't tested yet.
-         * It is likely to be OK anyway, so feel free to remove this UAVCAN_ASSERT() as needed.
-         */
-        UAVCAN_ASSERT(big_endian == false);
         if (big_endian)
         {
             swapByteOrder(bytes, Size);


### PR DESCRIPTION
We tested libuavcan on an NXP MPC5777m with the big endian assert removed and the endian conversion functionality works correctly.  We'd like to remove the endian assert for big endian machines.